### PR TITLE
feat: add contact form connected with EmailJs and recaptcha service

### DIFF
--- a/site/html/contact.html
+++ b/site/html/contact.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -31,7 +30,22 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous" defer></script>
-    
+
+    <!-- Email Service -->
+    <script type="text/javascript"
+        src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js">
+    </script>
+    <script type="text/javascript">
+      (function(){
+          emailjs.init({
+            publicKey: "your-public-key", // add your public key from Emailjs
+          });
+      })();
+    </script>
+
+    <!-- reCaptcha -->
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
     <title>NOSK - Nepal Open Source Klub</title>
 </head>
 <body>
@@ -91,15 +105,61 @@
     <!-- Main Body Starts Here-->
     
     <!--Section: Contact -->
-<section class="mb-4 ">
+<section class="mb-4 container">
 
     <!--Section heading-->
     <h2 class="h1-responsive font-weight-bold text-center my-4">Contact us</h2>
+    
     <!--Section description-->
     <p class="text-center w-responsive mx-auto mb-5">
-    Do you have any questions? 
-    You can reach out to us via mail at <a href="mailto:nosk@ncit.edu.np">nosk@ncit.edu.np</a>
-    </p>
+      Do you have any questions?
+      <br>
+      Fill this form below or directly reach out to us via mail at <a href="mailto:nosk@ncit.edu.np">nosk@ncit.edu.np</a>
+      </p>
+    <!-- Contact Form Starts Here -->
+    <form id="contact-form" name="contact-form">
+      <div class="row mb-3">
+          <!-- Name input -->
+          <div class="col-md-6">
+              <div class="form-outline">
+                <label class="form-label" for="name">Your Name</label>
+                  <input type="text" id="name" name="name" class="form-control" required>
+              </div>
+          </div>
+
+          <!-- Email input -->
+          <div class="col-md-6">
+              <div class="form-outline">
+                <label class="form-label" for="email">Your Email</label>
+                  <input type="email" id="email" name="email" class="form-control" required>
+              </div>
+          </div>
+      </div>
+
+      <!-- Subject input -->
+      <label class="form-label" for="subject">Subject</label>
+      <div class="form-outline mb-3">
+          <input type="text" id="subject" name="subject" class="form-control" required>
+      </div>
+
+      <!-- Message input -->
+      <div class="form-outline mb-4">
+        <label class="form-label" for="message">Your Message</label>
+          <textarea id="message" name="message" rows="4" class="form-control" required></textarea>
+      </div>
+
+      <!-- Captcha -->
+      <div class="g-recaptcha" data-sitekey="your-sitekey"></div> <!-- add your site key from google admin console-->
+
+      <!-- Send Button -->
+      <div class="text-center">
+          <button type="submit" class="btn btn-primary" id="submit">Send Message</button>
+      </div>
+    </form>
+    <!-- Contact Form Ends Here -->
+    
+
+   
 
 
 </section>
@@ -107,5 +167,6 @@
 
     <!-- including script.js for back to top button -->
     <script src="../js/script.js"></script>
+    <script src="../js/email.js"></script>
 </body>
 </html>

--- a/site/js/email.js
+++ b/site/js/email.js
@@ -1,0 +1,42 @@
+document
+  .getElementById("contact-form")
+  .addEventListener("submit", function (event) {
+    event.preventDefault(); // Prevent default form submission
+
+    if (validateCaptcha()) {
+      // Get form values
+      var name = document.getElementById("name").value;
+      var email = document.getElementById("email").value;
+      var subject = document.getElementById("subject").value;
+      var message = document.getElementById("message").value;
+
+      // Create the template parameters object
+      var templateParams = {
+        name: name,
+        subject: subject,
+        message: message,
+      };
+
+      // Send the email using EmailJS
+      emailjs.send("your_service_id", "your_template_id", templateParams).then( // replace with your service id and template id from Emailjs
+        function (response) {
+          console.log("SUCCESS!", response.status, response.text);
+          // On success, redirect to the success page
+          window.location.href = "/site/html/contact-success.html";
+        },
+        function (error) {
+          console.log("FAILED...", error);
+          alert("Failed to send message. Please try again later.");
+        }
+      );
+    }
+  });
+
+function validateCaptcha() {
+  const response = grecaptcha.getResponse();
+  if (response.length === 0) {
+    alert("Please verify the reCAPTCHA.");
+    return false; // Prevent form submission
+  }
+  return true; // Allow form submission
+}


### PR DESCRIPTION
This PR resolves #67. 

## Changes: 
- I have used EmailJs as mailing third party service. Maintainers will have to create their own public key, service-id and template-id.

- For captcha, I have used reCaptcha v2 service. Maintainer will have to create the site-key from the console page of GCP.

## Output:
![Screen Recording 2024-10-02 at 2 33 48 PM](https://github.com/user-attachments/assets/77c22794-a1d9-4db8-8b80-65375e40d267)
![Screenshot 2024-10-02 at 2 35 03 PM](https://github.com/user-attachments/assets/10b192d3-99cb-4a9d-bbc3-31a232f1e38b)


The template for the email can be changed from EmailJs Dashboard.